### PR TITLE
Limited GamePad Retries to avoid hanging if no gamepad is connected

### DIFF
--- a/source/utils/InputUtils.cpp
+++ b/source/utils/InputUtils.cpp
@@ -99,6 +99,7 @@ InputUtils::InputData InputUtils::getControllerInput() {
     InputData inputData{};
     VPADStatus vpadStatus{};
     VPADReadError vpadError = VPAD_READ_UNINITIALIZED;
+    int tests = 0;
     do {
         if (VPADRead(VPAD_CHAN_0, &vpadStatus, 1, &vpadError) > 0 && vpadError == VPAD_READ_SUCCESS) {
             inputData.trigger = vpadStatus.trigger;
@@ -107,7 +108,8 @@ InputUtils::InputData InputUtils::getControllerInput() {
         } else {
             OSSleepTicks(OSMillisecondsToTicks(1));
         }
-    } while (vpadError == VPAD_READ_NO_SAMPLES);
+        tests++;
+    } while (vpadError == VPAD_READ_NO_SAMPLES && tests <= 5);
 
     KPADStatus kpadStatus{};
     KPADError kpadError = KPAD_ERROR_UNINITIALIZED;


### PR DESCRIPTION
If a gamepad is not connected the input hangs until it can get data from one, so I modified the InputUntils.cpp to limit the amount of retries to get gamepad input to avoid such a hang while also still allowing some retries just in case, works with wiimotes but can't test with gamepad  as I don't have access to a working gamepad at the moment. Probably could just remove the do{} while(); and achieve a similar effect. 